### PR TITLE
Allow Bootstrap Run Script to be Executed as Root in Docker Container

### DIFF
--- a/bootstrap/run.sh
+++ b/bootstrap/run.sh
@@ -171,11 +171,14 @@ function bootstrap_project_init() {
 }
 
 function main() {
-  # Ensure this script is not executed by the root user
+  # Ensure this script is not executed by the root user,
+  # except when running inside a Docker container.
   if (( ${_EUID} == 0 )); then
-    echo "WARNING: There is no need for this program to be executed by the root user.";
-    echo "Please use a regular user instead.";
-    exit 1;
+    if ! [ -f "/.dockerenv" ]; then
+      echo "WARNING: There is no need for this program to be executed by the root user.";
+      echo "Please use a regular user instead.";
+      exit 1;
+    fi
   fi
   arg_version_str=false;
   arg_no_cache=false;


### PR DESCRIPTION
When bootstrapping Project Init via the bootstrap/run.sh script, it should be possible to do that from inside a Docker container, since root is often the only user. This improves the ability of clients to use the testing facilities together with the bootstap script.
