### PR TITLE
Improve Docker Integration in Java Projects by Caching Maven Dependencies

### DIFF
--- a/share/java/docker/Dockerfile-build
+++ b/share/java/docker/Dockerfile-build
@@ -36,6 +36,15 @@ RUN if [ $GID -ne 0 ] && [ $UID -ne 0 ]; then \
 # Use the user with the specified UID and GID
 USER $UID:$GID
 
+# Create .m2 directory for Maven with the above user.
+# If the Maven .m2 repository is persisted via a volume and does not exist when
+# the container is started, the Docker deamon will create the target directory
+# automatically. Thus, when using non-rootless, the directory will have root
+# ownership and the regular user won't be able to write to it. We therefore
+# make sure that the .m2 directory already exists and is owned
+# by the correct user.
+RUN mkdir -p ~/.m2
+
 # Working directory
 WORKDIR "$DWORKDIR"
 


### PR DESCRIPTION
Improves the shared project control code for Docker integration in Java projects to cache Maven artifacts.

For Java-based project templates with Docker integration, the Docker-related project control code is changed to add a Docker volume to the '_docker run_' command. Based on the underlying user inside the container, this persists the local _.m2_ Maven repository artifacts across Docker-based projects. This has the effect of caching all Maven dependencies when using the Docker integration for all Java-based projects. The artifacts are cached in a named volume 'maven-m2' and shared between containers on the same host. This improves build times in isolated environments using Docker.