### PR TITLE
Enable Docker Integration for Java 21

### DIFF
--- a/java/03_library_native_jni/source/.docker/Dockerfile-build
+++ b/java/03_library_native_jni/source/.docker/Dockerfile-build
@@ -13,12 +13,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment
 ENV TZ=UTC
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 # APT dependencies
 RUN apt-get -y update && apt-get -y --no-install-recommends install \
  build-essential \
- openjdk-17-jdk \
+ openjdk-21-jdk \
  maven \
  cmake \
  git \

--- a/java/init.sh
+++ b/java/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,10 +55,6 @@ function process_files_lvl_1() {
   replace_var "NAMESPACE_DECLARATION"              "$var_namespace";
   replace_var "NAMESPACE_DECLARATION_0"            "$var_namespace_0";
   replace_var "NAMESPACE_DECLARATION_TRAILING_SEP" "$var_namespace_trailing_sep";
-
-  if [[ "$var_project_integration_docker_enabled" == "1" && "$var_java_version" == "21" ]]; then
-    logW "Docker integration is not yet supported when using JDK 21";
-  fi
 
   if [ -z "$var_namespace" ]; then
     replace_var "NAMESPACE_PACKAGE_DECLARATION" "";

--- a/share/java/docker/Dockerfile-build
+++ b/share/java/docker/Dockerfile-build
@@ -13,11 +13,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment
 ENV TZ=UTC
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 # APT dependencies
 RUN apt-get -y update && apt-get -y --no-install-recommends install \
- openjdk-17-jdk \
+ openjdk-21-jdk \
  maven
 
 


### PR DESCRIPTION
Updates the Dockerfiles for isolated builds in Java-based projects.

Now uses the JDK-21 by default.
Removes warning from init code about the missing integration in Java 21.
