### PR TITLE
Change CMake Target Name Definitions to Apply In Global Scope

### DIFF
--- a/c/02_library/source/src/main/CMakeLists.txt
+++ b/c/02_library/source/src/main/CMakeLists.txt
@@ -5,7 +5,12 @@ include(GenerateExportHeader)
 #==================================[ TARGET ]==================================
 # Library ${{VAR_PROJECT_NAME}}
 
-set(${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN ${{VAR_ARTIFACT_BINARY_NAME}})
+set(${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN
+    ${{VAR_ARTIFACT_BINARY_NAME}}
+    CACHE
+    STRING
+    "Target name for the ${{VAR_PROJECT_NAME}} library"
+)
 
 set(${{VAR_PROJECT_NAME_UPPER}}_C_STANDARD ${{VAR_C_VERSION}})
 

--- a/cpp/02_library/source/src/main/CMakeLists.txt
+++ b/cpp/02_library/source/src/main/CMakeLists.txt
@@ -5,7 +5,12 @@ include(GenerateExportHeader)
 #==================================[ TARGET ]==================================
 # Library ${{VAR_PROJECT_NAME}}
 
-set(${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN ${{VAR_ARTIFACT_BINARY_NAME}})
+set(${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN
+    ${{VAR_ARTIFACT_BINARY_NAME}}
+    CACHE
+    STRING
+    "Target name for the ${{VAR_PROJECT_NAME}} library"
+)
 
 set(${{VAR_PROJECT_NAME_UPPER}}_CXX_STANDARD ${{VAR_CPP_VERSION}})
 


### PR DESCRIPTION
Changes the CMake variable definition in **C** and **C++** library projects in the main modules to have global scope such that the library target name can be referenced by other projects when it is consumed as a dependency.