### PR TITLE
Add Capability to Automatically Load Addon Library Files

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -129,6 +129,15 @@ sys.starttext.show=true
 # to be shown, the notify-send command must be available.
 sys.notification.success.show=true
 
+# A script file to source after an addon is loaded. This property must only be
+# defined in a 'project.properties' file of an addon. It is a path to a
+# script, relative to the addon's source tree, which gets automatically
+# sourced after the addon has been successfully loaded. This can be used to
+# put common code used throughout an addon into a separate file which acts like
+# a library, and instruct Project Init to automatically load it once the addon
+# is loaded. The code in the file is loaded into the global namespace.
+# sys.addon.code.load=mylibs.sh
+
 # ------------------------- Language-specific Settings ---------------------- #
 
 # ##### C settings


### PR DESCRIPTION
Introduces a property with key '_sys.addon.code.load_' which can be defined by addons.

Adds a check for a property 'sys.addon.code.load', which can be defined by an addon in its 'project.properties' file. The introduced property defines a path to a script file, relative to the addon's source tree root, which should be automatically loaded by the init system into the global namespace. The loading must occur before any user-specific properties are loaded in order to avoid redefinitions.

