### PR TITLE
Change Docker Integration Work Directory for Rootless Docker

### DIFF
--- a/js/02_server-nodejs/source/.docker/controls.sh
+++ b/js/02_server-nodejs/source/.docker/controls.sh
@@ -42,7 +42,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -52,7 +53,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/python/06_server-cherrypy/source/.docker/controls.sh
+++ b/python/06_server-cherrypy/source/.docker/controls.sh
@@ -15,6 +15,8 @@ readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
 readonly CONTAINER_BUILD_VERSION="0.1";
+# The project name inside the container
+readonly CONTAINER_PROJECT_NAME="${{VAR_PROJECT_NAME_LOWER}}";
 
 
 # Checks that the docker command is available.
@@ -45,7 +47,7 @@ function _check_docker() {
 function _docker_build() {
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${CONTAINER_PROJECT_NAME}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -55,7 +57,7 @@ function _docker_build() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${CONTAINER_PROJECT_NAME}";
   fi
   logI "Building Docker image";
   docker build --build-arg UID=${uid}                                   \
@@ -94,11 +96,11 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${CONTAINER_PROJECT_NAME}";
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${CONTAINER_PROJECT_NAME}";
   fi
   logI "Executing isolated $run_type";
   docker run --name ${CONTAINER_BUILD_NAME}                        \
@@ -139,11 +141,11 @@ function _start_interactive_isolated_tests() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${CONTAINER_PROJECT_NAME}";
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${CONTAINER_PROJECT_NAME}";
   fi
   logI "Starting isolated Docker container for interactive testing";
   docker run --name ${CONTAINER_BUILD_NAME}                        \

--- a/python/07_odoo_module/source/.docker/controls.sh
+++ b/python/07_odoo_module/source/.docker/controls.sh
@@ -45,7 +45,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -55,7 +56,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   logI "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/share/c/docker/controls.sh
+++ b/share/c/docker/controls.sh
@@ -42,7 +42,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -52,7 +53,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/share/cpp/docker/controls.sh
+++ b/share/cpp/docker/controls.sh
@@ -42,7 +42,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -52,7 +53,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/share/java/docker/controls.sh
+++ b/share/java/docker/controls.sh
@@ -43,7 +43,8 @@ function _run_isolated() {
   local uid=0;
   local gid=0;
   local user_home="/root";
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="${user_home}/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -54,7 +55,7 @@ function _run_isolated() {
     uid=$(id -u);
     gid=$(id -g);
     user_home="/home/user";
-    workdir="${user_home}${workdir}";
+    workdir="${user_home}/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/share/python/docker/controls.sh
+++ b/share/python/docker/controls.sh
@@ -42,7 +42,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -52,7 +53,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \

--- a/share/r/docker/controls.sh
+++ b/share/r/docker/controls.sh
@@ -42,7 +42,8 @@ function _run_isolated() {
 
   local uid=0;
   local gid=0;
-  local workdir="/${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir_name="${{VAR_PROJECT_NAME_LOWER}}";
+  local workdir="/root/${workdir_name}";
   # When using non-rootless Docker, the user inside the container should be a
   # regular user. We assign him the same UID and GID as the underlying host
   # user so that there are no conflicts when bind-mounting the source tree.
@@ -52,7 +53,7 @@ function _run_isolated() {
   if ! docker info 2>/dev/null |grep -q "rootless"; then
     uid=$(id -u);
     gid=$(id -g);
-    workdir="/home/user${workdir}";
+    workdir="/home/user/${workdir_name}";
   fi
   echo "Building Docker image";
   docker build --build-arg UID=${uid}                                   \


### PR DESCRIPTION
Changes the Docker integration project control code to use the root user's home directory.

In project control code of all templates providing Docker integration, the setting of the work directory inside the build container is changed to the home directory of the root user when the underlying host is using rootless-Docker.
