### PR TITLE
Add Build Script Options to Control Build Configure Step

### DIFF
--- a/c/01_executable/source/build.sh
+++ b/c/01_executable/source/build.sh
@@ -10,22 +10,31 @@ ${USAGE}
 
 Options:
 
-  [--clean]      Remove all build-related directories and files and then exit.
+  [--clean]       Remove all build-related directories and files and then exit.
 
-  [--debug]      Build the application with debug symbols and with
-                 optimizations turned off.
+  [--config]      Only execute the build configuration step. This option will skip
+                  the build step.
+
+  [--debug]       Build the application with debug symbols and with
+                  optimizations turned off.
 ${{VAR_SCRIPT_BUILD_ISOLATED_OPT}}
 
-  [--skip-tests] Do not build any tests.
+  [--skip-config] Skip the build configuration step. If the build tree does not
+                  exist yet, then this option has no effect and the build
+                  configuration step is executed.
 
-  [-?|--help]    Show this help message.
+  [--skip-tests]  Do not build any tests.
+
+  [-?|--help]     Show this help message.
 EOS
 )
 
 # Arg flags
 ARG_CLEAN=false;
+ARG_CONFIG=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
+ARG_SKIP_CONFIG=false;
 ARG_SKIP_TESTS=false;
 ARG_SHOW_HELP=false;
 
@@ -38,8 +47,18 @@ for arg in "$@"; do
     ARG_CLEAN=true;
     shift
     ;;
+    --config)
+    ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
     --debug)
     ARG_DEBUG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --skip-config)
+    ARG_SKIP_CONFIG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -107,13 +126,24 @@ if [[ $ARG_SKIP_TESTS == true ]]; then
 fi
 
 # CMake: Configure
-cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
-      -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" ..;
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" ..;
 
-if (( $? != 0 )); then
-  exit $?;
+  config_status=$?;
+  if (( config_status != 0 )); then
+    exit $config_status;
+  fi
+  if [[ $ARG_CONFIG == true ]]; then
+    exit $config_status;
+  fi
+fi
+
+CMAKE_CONFIG_ARG="";
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  CMAKE_CONFIG_ARG="--config $BUILD_CONFIGURATION";
 fi
 
 # CMake: Build
-cmake --build . --config "$BUILD_CONFIGURATION";
+cmake --build . $CMAKE_CONFIG_ARG;
 exit $?;

--- a/c/01_executable/source/build.sh
+++ b/c/01_executable/source/build.sh
@@ -89,6 +89,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/c/02_library/source/build.sh
+++ b/c/02_library/source/build.sh
@@ -97,6 +97,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/c/var/script_build_isolated_opt
+++ b/c/var/script_build_isolated_opt
@@ -1,0 +1,2 @@
+
+  [--isolated]    Execute the entire build process in an isolated Docker container.

--- a/cpp/01_executable/source/build.sh
+++ b/cpp/01_executable/source/build.sh
@@ -10,22 +10,31 @@ ${USAGE}
 
 Options:
 
-  [--clean]      Remove all build-related directories and files and then exit.
+  [--clean]       Remove all build-related directories and files and then exit.
 
-  [--debug]      Build the application with debug symbols and with
-                 optimizations turned off.
+  [--config]      Only execute the build configuration step. This option will skip
+                  the build step.
+
+  [--debug]       Build the application with debug symbols and with
+                  optimizations turned off.
 ${{VAR_SCRIPT_BUILD_ISOLATED_OPT}}
 
-  [--skip-tests] Do not build any tests.
+  [--skip-config] Skip the build configuration step. If the build tree does not
+                  exist yet, then this option has no effect and the build
+                  configuration step is executed.
 
-  [-?|--help]    Show this help message.
+  [--skip-tests]  Do not build any tests.
+
+  [-?|--help]     Show this help message.
 EOS
 )
 
 # Arg flags
 ARG_CLEAN=false;
+ARG_CONFIG=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
+ARG_SKIP_CONFIG=false;
 ARG_SKIP_TESTS=false;
 ARG_SHOW_HELP=false;
 
@@ -38,8 +47,18 @@ for arg in "$@"; do
     ARG_CLEAN=true;
     shift
     ;;
+    --config)
+    ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
     --debug)
     ARG_DEBUG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --skip-config)
+    ARG_SKIP_CONFIG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -107,13 +126,24 @@ if [[ $ARG_SKIP_TESTS == true ]]; then
 fi
 
 # CMake: Configure
-cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
-      -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" ..;
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" ..;
 
-if (( $? != 0 )); then
-  exit $?;
+  config_status=$?;
+  if (( config_status != 0 )); then
+    exit $config_status;
+  fi
+  if [[ $ARG_CONFIG == true ]]; then
+    exit $config_status;
+  fi
+fi
+
+CMAKE_CONFIG_ARG="";
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  CMAKE_CONFIG_ARG="--config $BUILD_CONFIGURATION";
 fi
 
 # CMake: Build
-cmake --build . --config "$BUILD_CONFIGURATION";
+cmake --build . $CMAKE_CONFIG_ARG;
 exit $?;

--- a/cpp/01_executable/source/build.sh
+++ b/cpp/01_executable/source/build.sh
@@ -89,6 +89,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/cpp/02_library/source/build.sh
+++ b/cpp/02_library/source/build.sh
@@ -10,24 +10,33 @@ ${USAGE}
 
 Options:
 
-  [--clean]      Remove all build-related directories and files and then exit.
+  [--clean]       Remove all build-related directories and files and then exit.
 
-  [--debug]      Build the libraries with debug symbols and with
-                 optimizations turned off.
+  [--config]      Only execute the build configuration step. This option will skip
+                  the build step.
+
+  [--debug]       Build the libraries with debug symbols and with
+                  optimizations turned off.
 ${{VAR_SCRIPT_BUILD_ISOLATED_OPT}}
 
-  [--shared]     Build shared libraries instead of static libraries.
+  [--shared]      Build shared libraries instead of static libraries.
 
-  [--skip-tests] Do not build any tests.
+  [--skip-config] Skip the build configuration step. If the build tree does not
+                  exist yet, then this option has no effect and the build
+                  configuration step is executed.
 
-  [-?|--help]    Show this help message.
+  [--skip-tests]  Do not build any tests.
+
+  [-?|--help]     Show this help message.
 EOS
 )
 
 # Arg flags
 ARG_CLEAN=false;
+ARG_CONFIG=false;
 ARG_SHARED=false;
 ARG_DEBUG=false;
+ARG_SKIP_CONFIG=false;
 ARG_SKIP_TESTS=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
 ARG_SHOW_HELP=false;
@@ -41,6 +50,11 @@ for arg in "$@"; do
     ARG_CLEAN=true;
     shift
     ;;
+    --config)
+    ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
     --shared)
     ARG_SHARED=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
@@ -48,6 +62,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     ;;
     --debug)
     ARG_DEBUG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --skip-config)
+    ARG_SKIP_CONFIG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -121,14 +140,25 @@ if [[ $ARG_SHARED == true ]]; then
 fi
 
 # CMake: Configure
-cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
-      -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
-      -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" .. ;
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" .. ;
 
-if (( $? != 0 )); then
-  exit $?;
+  config_status=$?;
+  if (( config_status != 0 )); then
+    exit $config_status;
+  fi
+  if [[ $ARG_CONFIG == true ]]; then
+    exit $config_status;
+  fi
+fi
+
+CMAKE_CONFIG_ARG="";
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  CMAKE_CONFIG_ARG="--config $BUILD_CONFIGURATION";
 fi
 
 # CMake: Build
-cmake --build . --config "$BUILD_CONFIGURATION";
+cmake --build . $CMAKE_CONFIG_ARG;
 exit $?;

--- a/cpp/02_library/source/build.sh
+++ b/cpp/02_library/source/build.sh
@@ -97,6 +97,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/cpp/03_server-poco/source/build.sh
+++ b/cpp/03_server-poco/source/build.sh
@@ -97,6 +97,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/cpp/03_server-poco/source/build.sh
+++ b/cpp/03_server-poco/source/build.sh
@@ -12,11 +12,18 @@ Options:
 
   [--clean]       Remove all build-related directories and files and then exit.
 
+  [--config]      Only execute the build configuration step. This option will skip
+                  the build step.
+
   [--debug]       Build the application with debug symbols and with
                   optimizations turned off.
 ${{VAR_SCRIPT_BUILD_ISOLATED_OPT}}
 
   [--shared-libs] Build dependencies as shared libraries.
+
+  [--skip-config] Skip the build configuration step. If the build tree does not
+                  exist yet, then this option has no effect and the build
+                  configuration step is executed.
 
   [--skip-tests]  Do not build any tests.
 
@@ -26,9 +33,11 @@ EOS
 
 # Arg flags
 ARG_CLEAN=false;
+ARG_CONFIG=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
 ARG_SHARED_LIBS=false;
+ARG_SKIP_CONFIG=false;
 ARG_SKIP_TESTS=false;
 ARG_SHOW_HELP=false;
 
@@ -41,6 +50,11 @@ for arg in "$@"; do
     ARG_CLEAN=true;
     shift
     ;;
+    --config)
+    ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
     --debug)
     ARG_DEBUG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
@@ -48,6 +62,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     ;;
     --shared-libs)
     ARG_SHARED_LIBS=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --skip-config)
+    ARG_SKIP_CONFIG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -121,14 +140,25 @@ if [[ $ARG_SKIP_TESTS == true ]]; then
 fi
 
 # CMake: Configure
-cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
-      -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" \
-      -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" .. ;
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
+        -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" .. ;
 
-if (( $? != 0 )); then
-  exit $?;
+  config_status=$?;
+  if (( config_status != 0 )); then
+    exit $config_status;
+  fi
+  if [[ $ARG_CONFIG == true ]]; then
+    exit $config_status;
+  fi
+fi
+
+CMAKE_CONFIG_ARG="";
+if [[ $ARG_SKIP_CONFIG == false ]]; then
+  CMAKE_CONFIG_ARG="--config $BUILD_CONFIGURATION";
 fi
 
 # CMake: Build
-cmake --build . --config "$BUILD_CONFIGURATION";
+cmake --build . $CMAKE_CONFIG_ARG;
 exit $?;

--- a/cpp/04_desktop_imgui/source/build.sh
+++ b/cpp/04_desktop_imgui/source/build.sh
@@ -80,6 +80,11 @@ if [[ $ARG_SHOW_HELP == true ]]; then
   exit 0;
 fi
 
+if [[ $ARG_CONFIG == true && $ARG_SKIP_CONFIG == true ]]; then
+  echo "Cannot specify both --config and --skip-config options";
+  exit 1;
+fi
+
 # Check clean flag
 if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then

--- a/cpp/var/script_build_isolated_opt
+++ b/cpp/var/script_build_isolated_opt
@@ -1,0 +1,2 @@
+
+  [--isolated]    Execute the entire build process in an isolated Docker container.


### PR DESCRIPTION
 Improves all **C** and **C++** build scripts by adding configure step control options.

Adds the following default options in build script:
* `--config`
* `--skip-config`

Additionally, adds a var file in C and C++ project template directories to override the isolated option text so that the formatting in the build script help text is coherent.