### PR TITLE
Use Python Build Frontend and Place Dist Under Build Tree

### DIFF
--- a/python/01_installable_script/source/build.sh
+++ b/python/01_installable_script/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/01_installable_script/source/deploy.sh
+++ b/python/01_installable_script/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/01_installable_script/source/pyproject.toml
+++ b/python/01_installable_script/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/01_installable_script/source/requirements.txt
+++ b/python/01_installable_script/source/requirements.txt
@@ -1,2 +1,1 @@
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
+${{INCLUDE:python/requirements.txt}}

--- a/python/02_library/source/build.sh
+++ b/python/02_library/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/02_library/source/deploy.sh
+++ b/python/02_library/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/02_library/source/pyproject.toml
+++ b/python/02_library/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/02_library/source/requirements.txt
+++ b/python/02_library/source/requirements.txt
@@ -1,2 +1,1 @@
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
+${{INCLUDE:python/requirements.txt}}

--- a/python/03_library_native_ctypes/source/build.sh
+++ b/python/03_library_native_ctypes/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/03_library_native_ctypes/source/deploy.sh
+++ b/python/03_library_native_ctypes/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/03_library_native_ctypes/source/pyproject.toml
+++ b/python/03_library_native_ctypes/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/03_library_native_ctypes/source/requirements.txt
+++ b/python/03_library_native_ctypes/source/requirements.txt
@@ -1,2 +1,1 @@
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
+${{INCLUDE:python/requirements.txt}}

--- a/python/04_library_native_cext/source/build.sh
+++ b/python/04_library_native_cext/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/04_library_native_cext/source/deploy.sh
+++ b/python/04_library_native_cext/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/04_library_native_cext/source/pyproject.toml
+++ b/python/04_library_native_cext/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/04_library_native_cext/source/requirements.txt
+++ b/python/04_library_native_cext/source/requirements.txt
@@ -1,2 +1,1 @@
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
+${{INCLUDE:python/requirements.txt}}

--- a/python/05_library_native_cython/source/build.sh
+++ b/python/05_library_native_cython/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} -m build;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/05_library_native_cython/source/deploy.sh
+++ b/python/05_library_native_cython/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/05_library_native_cython/source/requirements.txt
+++ b/python/05_library_native_cython/source/requirements.txt
@@ -1,4 +1,2 @@
+${{INCLUDE:python/requirements.txt}}
 cython==3.0.5
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
-build==0.7.0

--- a/python/06_server-cherrypy/source/build.sh
+++ b/python/06_server-cherrypy/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/06_server-cherrypy/source/deploy.sh
+++ b/python/06_server-cherrypy/source/deploy.sh
@@ -51,7 +51,6 @@ if [[ $ARG_SHOW_HELP == true ]]; then
 fi
 
 # Source setup script
-SETUPSH_VIRTUALENV_AUTO_ACTIVATE="0";
 if ! source "setup.sh"; then
   exit 1;
 fi
@@ -69,7 +68,7 @@ if (( $? != 0 )); then
 fi
 
 logI "Running distribution checks";
-twine check dist/*;
+twine check build/dist/*;
 if (( $? != 0 )); then
   logE "Distribution checks have failed";
   exit 1;
@@ -78,14 +77,14 @@ logI "All distribution checks have passed";
 
 if [[ $ARG_TESTPYPI == true ]]; then
   logI "Uploading distributions to TestPyPI";
-  twine upload --repository testpypi dist/*;
+  twine upload --repository testpypi build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;
   fi
 else
   logI "Uploading distributions to PyPI";
-  twine upload dist/*;
+  twine upload build/dist/*;
   if (( $? != 0 )); then
     logE "Failed to upload distributions";
     exit 1;

--- a/python/06_server-cherrypy/source/pyproject.toml
+++ b/python/06_server-cherrypy/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/06_server-cherrypy/source/requirements.txt
+++ b/python/06_server-cherrypy/source/requirements.txt
@@ -1,4 +1,2 @@
+${{INCLUDE:python/requirements.txt}}
 CherryPy==18.8.0
-${{VAR_REQUIREMENTS_LINT}}
-${{VAR_REQUIREMENTS_DEPLOY}}
-

--- a/python/07_odoo_module/init.sh
+++ b/python/07_odoo_module/init.sh
@@ -124,6 +124,9 @@ function process_files_lvl_2() {
     replace_var "MANIFEST_WIZARD_DECL" "";
   fi
   replace_var "ODOO_MODULE_NAME" "$var_odoo_module_name";
+  # Remove unsupported lines from copied requirements.txt file.
+  replace_var "REQUIREMENTS_LINT"   "";
+  replace_var "REQUIREMENTS_DEPLOY" "";
 }
 
 # Validation function for the Odoo module name form question.

--- a/python/07_odoo_module/source/build.sh
+++ b/python/07_odoo_module/source/build.sh
@@ -79,9 +79,6 @@ if [[ $ARG_CLEAN == true ]]; then
   if [ -d "build" ]; then
     rm -r "build";
   fi
-  if [ -d "dist" ]; then
-    rm -r "dist";
-  fi
   if [ -d *.egg-info ]; then
     rm -r *.egg-info;
   fi
@@ -112,7 +109,7 @@ if [[ $ARG_SKIP_TESTS == false ]]; then
 fi
 
 logI "Building source and binary distribution packages";
-${_PYTHON_EXEC} setup.py sdist bdist_wheel;
+${_PYTHON_EXEC} -m build --outdir build/dist --no-isolation;
 if (( $? != 0 )); then
   logE "Failed to build distribution packages";
   exit 1;

--- a/python/07_odoo_module/source/pyproject.toml
+++ b/python/07_odoo_module/source/pyproject.toml
@@ -1,0 +1,1 @@
+${{INCLUDE:python/pyproject.toml}}

--- a/python/07_odoo_module/source/requirements.txt
+++ b/python/07_odoo_module/source/requirements.txt
@@ -1,0 +1,1 @@
+${{INCLUDE:python/requirements.txt}}

--- a/share/python/pyproject.toml
+++ b/share/python/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel"
+]
+
+build-backend = "setuptools.build_meta"

--- a/share/python/requirements.txt
+++ b/share/python/requirements.txt
@@ -1,0 +1,5 @@
+build==1.0.3
+setuptools==69.1.1
+wheel==0.42.0
+${{VAR_REQUIREMENTS_LINT}}
+${{VAR_REQUIREMENTS_DEPLOY}}

--- a/tests/test_func_python_installable_script.sh
+++ b/tests/test_func_python_installable_script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ function test_functionality_result() {
   files+=(".global.sh");
   files+=("setup.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("deploy.sh");
   files+=("requirements.txt");
   files+=("pylintrc");

--- a/tests/test_func_python_library.sh
+++ b/tests/test_func_python_library.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ function test_functionality_result() {
   files+=(".global.sh");
   files+=("setup.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("deploy.sh");
   files+=("requirements.txt");
   files+=("pylintrc");

--- a/tests/test_func_python_library_native_cext.sh
+++ b/tests/test_func_python_library_native_cext.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ function test_functionality_result() {
   files+=(".global.sh");
   files+=("setup.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("deploy.sh");
   files+=("requirements.txt");
   files+=("pylintrc");

--- a/tests/test_func_python_library_native_ctypes.sh
+++ b/tests/test_func_python_library_native_ctypes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ function test_functionality_result() {
   files+=(".global.sh");
   files+=("setup.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("deploy.sh");
   files+=("requirements.txt");
   files+=("pylintrc");

--- a/tests/test_func_python_odoo_module.sh
+++ b/tests/test_func_python_odoo_module.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ function test_functionality_result() {
   files+=("build.sh");
   files+=("test.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("MANIFEST.in");
   files+=("requirements.txt");
   files+=(".docker/Dockerfile-build");

--- a/tests/test_func_python_server-cherrypy.sh
+++ b/tests/test_func_python_server-cherrypy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2024 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ function test_functionality_result() {
   files+=(".global.sh");
   files+=("setup.sh");
   files+=("setup.py");
+  files+=("pyproject.toml");
   files+=("main.py");
   files+=("requirements.txt");
   files+=("raven/application.py");


### PR DESCRIPTION
Changes Python project source templates to use a standard build frontend.
Changes the default location of the build '_dist_' directory generated by the build system to be located under the build tree.
