### PR TITLE
Specify Build Config When Using CTest

### DIFF
--- a/c/01_executable/source/test.sh
+++ b/c/01_executable/source/test.sh
@@ -82,6 +82,13 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/c/02_library/source/test.sh
+++ b/c/02_library/source/test.sh
@@ -82,6 +82,13 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/cpp/01_executable/source/test.sh
+++ b/cpp/01_executable/source/test.sh
@@ -82,11 +82,18 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # By default, GTest does not use colourful output when logging
 # the test results to a file. But as we also show the tests
 # in a terminal, we explicitly activate colourful output.
 export GTEST_COLOR=1;
 
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/cpp/02_library/source/test.sh
+++ b/cpp/02_library/source/test.sh
@@ -82,11 +82,18 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # By default, GTest does not use colourful output when logging
 # the test results to a file. But as we also show the tests
 # in a terminal, we explicitly activate colourful output.
 export GTEST_COLOR=1;
 
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/cpp/03_server-poco/source/test.sh
+++ b/cpp/03_server-poco/source/test.sh
@@ -80,11 +80,18 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # By default, GTest does not use colourful output when logging
 # the test results to a file. But as we also show the tests
 # in a terminal, we explicitly activate colourful output.
 export GTEST_COLOR=1;
 
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/cpp/04_desktop_imgui/source/test.sh
+++ b/cpp/04_desktop_imgui/source/test.sh
@@ -75,11 +75,18 @@ if (( $? != 0 )); then
   exit $?;
 fi
 
+BUILD_CONFIGURATION="";
+# Determine the build configuration of the last build.
+if [ -f "CMakeCache.txt" ]; then
+  BUILD_CONFIGURATION="$(grep --max-count=1 CMAKE_BUILD_TYPE CMakeCache.txt \
+                         | cut  --delimiter='=' --fields=2)";
+fi
+
 # By default, GTest does not use colourful output when logging
 # the test results to a file. But as we also show the tests
 # in a terminal, we explicitly activate colourful output.
 export GTEST_COLOR=1;
 
 # Run tests with CTest
-ctest --output-on-failure;
+ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;


### PR DESCRIPTION
Adds the build configuration specification to the _test.sh_ scripts of _C_ and _C++_ project source templates.
