### PR TITLE
Improve Docker Project Control Code

### DIFF
--- a/js/02_server-nodejs/source/.docker/controls.sh
+++ b/js/02_server-nodejs/source/.docker/controls.sh
@@ -13,7 +13,7 @@
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated runs
-ROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-run";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-run";
 # The name given to the image and container
 PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}";
 # The version tag given to the image and container
@@ -74,8 +74,9 @@ function project_run_isolated() {
                  --tag "$name_tag"                                     \
                  --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/js/02_server-nodejs/source/.docker/controls.sh
+++ b/js/02_server-nodejs/source/.docker/controls.sh
@@ -12,10 +12,10 @@
 #                                                                             #
 ###############################################################################
 
-# The Dockerfile to be used for creating images for isolated builds
-PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+# The Dockerfile to be used for creating images for isolated runs
+ROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-run";
 # The name given to the image and container
-PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}";
 # The version tag given to the image and container
 PROJECT_CONTAINER_BUILD_VERSION="0.1";
 

--- a/js/02_server-nodejs/source/.docker/controls.sh
+++ b/js/02_server-nodejs/source/.docker/controls.sh
@@ -6,22 +6,28 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # run the underlying project inside a Docker container.                       #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
-# The Dockerfile to be used for creating images for isolated runs
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-run";
+# The Dockerfile to be used for creating images for isolated builds
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
 #
 # This function builds the image, creates a container from it
 # and then runs that container. The container is removed after
-# the execution has completed
+# the execution has completed.
+#
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
 #
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -55,19 +65,22 @@ function _run_isolated() {
     gid=$(id -g);
     workdir="/home/user/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                                \
+                 --build-arg GID=${gid}                                \
+                 --build-arg DWORKDIR="${workdir}"                     \
+                 --tag "$name_tag"                                     \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                        \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                \
              --interactive                                         \
              --tty                                                 \
              --init                                                \
@@ -75,29 +88,9 @@ function _run_isolated() {
              --user ${uid}:${gid}                                  \
              --rm                                                  \
              --publish 8080:8080                                   \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}    \
-             "$run_type"                                           \
+             "$name_tag"                                           \
+             "$isolated_command"                                   \
              "$@";
 
-  return $?;
-}
-
-# Executes the application in an isolated process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's run.sh script
-#      to customise the execution.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed run.sh script
-# is returned instead.
-#
-function run_isolated_app() {
-  _run_isolated "app" "$@";
   return $?;
 }

--- a/js/var/script_run_isolated_main
+++ b/js/var/script_run_isolated_main
@@ -1,5 +1,5 @@
 if [[ $ARG_ISOLATED == true ]]; then
   source ".docker/controls.sh";
-  run_isolated_app "${ARGS_ISOLATED[@]}";
+  project_run_isolated app "${ARGS_ISOLATED[@]}";
   exit $?;
 fi

--- a/python/06_server-cherrypy/var/script_test_isolated_main
+++ b/python/06_server-cherrypy/var/script_test_isolated_main
@@ -1,0 +1,5 @@
+if [[ $ARG_ISOLATED == true ]]; then
+  source ".docker/controls.sh";
+  project_run_isolated_tests "${ARGS_ISOLATED[@]}";
+  exit $?;
+fi

--- a/python/07_odoo_module/source/.docker/docker-compose-test.yaml
+++ b/python/07_odoo_module/source/.docker/docker-compose-test.yaml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   web:
     image: odoo:16

--- a/python/07_odoo_module/var/script_test_isolated_main
+++ b/python/07_odoo_module/var/script_test_isolated_main
@@ -1,0 +1,5 @@
+if [[ $ARG_ISOLATED == true ]]; then
+  source ".docker/controls.sh";
+  project_run_isolated_tests "${ARGS_ISOLATED[@]}";
+  exit $?;
+fi

--- a/share/c/docker/controls.sh
+++ b/share/c/docker/controls.sh
@@ -74,8 +74,9 @@ function project_run_isolated() {
                  --tag "$name_tag"                                     \
                  --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/share/c/docker/controls.sh
+++ b/share/c/docker/controls.sh
@@ -6,15 +6,18 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # either build or test the underlying project inside a Docker container.      #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated builds
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
@@ -23,6 +26,9 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # and then runs that container. The container is removed after
 # the execution has completed.
 #
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
+#
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
 #
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -55,66 +65,30 @@ function _run_isolated() {
     gid=$(id -g);
     workdir="/home/user/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                                \
+                 --build-arg GID=${gid}                                \
+                 --build-arg DWORKDIR="${workdir}"                     \
+                 --tag "$name_tag"                                     \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                        \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                \
              --mount type=bind,source="${PWD}",target="${workdir}" \
              --user ${uid}:${gid}                                  \
              --rm                                                  \
              --tty                                                 \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}    \
-             "$run_type"                                           \
+             --interactive                                         \
+             "$name_tag"                                           \
+             "$isolated_command"                                   \
              "$@";
 
-  return $?;
-}
-
-# Executes an isolated build process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's build.sh script
-#      to customise the build.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed build.sh script
-# is returned instead.
-#
-function run_isolated_build() {
-  _run_isolated "build" "$@";
-  return $?;
-}
-
-# Executes an isolated test process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's test.sh script
-#      to customise the test process.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed test.sh script
-# is returned instead.
-#
-function run_isolated_tests() {
-  _run_isolated "tests" "$@";
   return $?;
 }

--- a/share/cpp/docker/controls.sh
+++ b/share/cpp/docker/controls.sh
@@ -74,8 +74,9 @@ function project_run_isolated() {
                  --tag "$name_tag"                                     \
                  --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/share/cpp/docker/controls.sh
+++ b/share/cpp/docker/controls.sh
@@ -6,15 +6,18 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # either build or test the underlying project inside a Docker container.      #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated builds
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
@@ -23,6 +26,9 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # and then runs that container. The container is removed after
 # the execution has completed.
 #
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
+#
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
 #
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -55,66 +65,30 @@ function _run_isolated() {
     gid=$(id -g);
     workdir="/home/user/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                                \
+                 --build-arg GID=${gid}                                \
+                 --build-arg DWORKDIR="${workdir}"                     \
+                 --tag "$name_tag"                                     \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                        \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                \
              --mount type=bind,source="${PWD}",target="${workdir}" \
              --user ${uid}:${gid}                                  \
              --rm                                                  \
              --tty                                                 \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}    \
-             "$run_type"                                           \
+             --interactive                                         \
+             "$name_tag"                                           \
+             "$isolated_command"                                   \
              "$@";
 
-  return $?;
-}
-
-# Executes an isolated build process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's build.sh script
-#      to customise the build.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed build.sh script
-# is returned instead.
-#
-function run_isolated_build() {
-  _run_isolated "build" "$@";
-  return $?;
-}
-
-# Executes an isolated test process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's test.sh script
-#      to customise the test process.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed test.sh script
-# is returned instead.
-#
-function run_isolated_tests() {
-  _run_isolated "tests" "$@";
   return $?;
 }

--- a/share/java/docker/controls.sh
+++ b/share/java/docker/controls.sh
@@ -6,22 +6,28 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # either build or test the underlying project inside a Docker container.      #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated builds
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
 #
 # This function builds the image, creates a container from it
 # and then runs that container. The container is removed after
-# the execution has completed
+# the execution has completed.
+#
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
 #
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -57,67 +67,31 @@ function _run_isolated() {
     user_home="/home/user";
     workdir="${user_home}/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                        \
+                 --build-arg GID=${gid}                        \
+                 --build-arg DWORKDIR="${workdir}"             \
+                 --tag "$name_tag"                             \
+                 --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                                \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                        \
              --mount type=bind,source="${PWD}",target="${workdir}"         \
              --mount type=volume,source=maven-m2,target="${user_home}/.m2" \
              --user ${uid}:${gid}                                          \
              --rm                                                          \
              --tty                                                         \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}            \
-             "$run_type"                                                   \
+             --interactive                                                 \
+             "$name_tag"                                                   \
+             "$isolated_command"                                           \
              "$@";
 
-  return $?;
-}
-
-# Executes an isolated build process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's build.sh script
-#      to customise the build.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed build.sh script
-# is returned instead.
-#
-function run_isolated_build() {
-  _run_isolated "build" "$@";
-  return $?;
-}
-
-# Executes an isolated test process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's test.sh script
-#      to customise the test process.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed test.sh script
-# is returned instead.
-#
-function run_isolated_tests() {
-  _run_isolated "tests" "$@";
   return $?;
 }

--- a/share/java/docker/controls.sh
+++ b/share/java/docker/controls.sh
@@ -70,14 +70,15 @@ function project_run_isolated() {
   local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
   if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
     echo "Building Docker image";
-    docker build --build-arg UID=${uid}                        \
-                 --build-arg GID=${gid}                        \
-                 --build-arg DWORKDIR="${workdir}"             \
-                 --tag "$name_tag"                             \
-                 --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+    docker build --build-arg UID=${uid}                               \
+                 --build-arg GID=${gid}                               \
+                 --build-arg DWORKDIR="${workdir}"                    \
+                 --tag "$name_tag"                                    \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/share/python/docker/controls.sh
+++ b/share/python/docker/controls.sh
@@ -6,22 +6,28 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # either build or test the underlying project inside a Docker container.      #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated builds
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
 #
 # This function builds the image, creates a container from it
 # and then runs that container. The container is removed after
-# the execution has completed
+# the execution has completed.
+#
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
 #
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -55,66 +65,30 @@ function _run_isolated() {
     gid=$(id -g);
     workdir="/home/user/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                                \
+                 --build-arg GID=${gid}                                \
+                 --build-arg DWORKDIR="${workdir}"                     \
+                 --tag "$name_tag"                                     \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                        \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                \
              --mount type=bind,source="${PWD}",target="${workdir}" \
              --user ${uid}:${gid}                                  \
              --rm                                                  \
              --tty                                                 \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}    \
-             "$run_type"                                           \
+             --interactive                                         \
+             "$name_tag"                                           \
+             "$isolated_command"                                   \
              "$@";
 
-  return $?;
-}
-
-# Executes an isolated build process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's build.sh script
-#      to customise the build.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed build.sh script
-# is returned instead.
-#
-function run_isolated_build() {
-  _run_isolated "build" "$@";
-  return $?;
-}
-
-# Executes an isolated test process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's test.sh script
-#      to customise the test process.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed test.sh script
-# is returned instead.
-#
-function run_isolated_tests() {
-  _run_isolated "tests" "$@";
   return $?;
 }

--- a/share/python/docker/controls.sh
+++ b/share/python/docker/controls.sh
@@ -74,8 +74,9 @@ function project_run_isolated() {
                  --tag "$name_tag"                                     \
                  --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/share/r/docker/controls.sh
+++ b/share/r/docker/controls.sh
@@ -6,22 +6,28 @@
 # This shell script provides functions to handle isolated executions          #
 # via Docker. Users may source this file and call the provided functions to   #
 # either build or test the underlying project inside a Docker container.      #
+# This can also be used to run arbitrary commands inside an isolated          #
+# container or to get an interactive shell. Some execution parameters         #
+# can be controlled by setting various PROJECT_CONTAINER_* variables.         #
 #                                                                             #
 ###############################################################################
 
 # The Dockerfile to be used for creating images for isolated builds
-readonly CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
+PROJECT_CONTAINER_BUILD_DOCKERFILE="Dockerfile-build";
 # The name given to the image and container
-readonly CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
+PROJECT_CONTAINER_BUILD_NAME="${{VAR_PROJECT_NAME_LOWER}}-build";
 # The version tag given to the image and container
-readonly CONTAINER_BUILD_VERSION="0.1";
+PROJECT_CONTAINER_BUILD_VERSION="0.1";
 
 
 # Executes an isolated command inside a Docker container.
 #
 # This function builds the image, creates a container from it
 # and then runs that container. The container is removed after
-# the execution has completed
+# the execution has completed.
+#
+# The building of the Docker image can be suppressed by setting the
+# environment variable PROJECT_CONTAINER_IMAGE_BUILD to the value "0".
 #
 # Args:
 # $@ - The arguments to be passed to the container's entrypoint.
@@ -30,12 +36,16 @@ readonly CONTAINER_BUILD_VERSION="0.1";
 # Either the exit status of the Docker-related commands, if unsuccessful,
 # or the exit status of the specified command.
 #
-function _run_isolated() {
-  local run_type="$1";
+function project_run_isolated() {
+  local isolated_command="$1";
   shift;
+  if [ -z "$isolated_command" ]; then
+    echo "ERROR: Must provide a command to run in isolation";
+    return 1;
+  fi
   if ! command -v "docker" &> /dev/null; then
     echo "ERROR: Could not find the 'docker' executable.";
-    echo "If you want the $run_type to be executed in an isolated environment,";
+    echo "If you want a command to be executed in an isolated environment,";
     echo "please make sure that Docker is correctly installed ";
     return 1;
   fi
@@ -55,66 +65,30 @@ function _run_isolated() {
     gid=$(id -g);
     workdir="/home/user/${workdir_name}";
   fi
-  echo "Building Docker image";
-  docker build --build-arg UID=${uid}                                   \
-               --build-arg GID=${gid}                                   \
-               --build-arg DWORKDIR="${workdir}"                        \
-               --tag ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION} \
-               --file .docker/${CONTAINER_BUILD_DOCKERFILE} .
+  local name_tag="${PROJECT_CONTAINER_BUILD_NAME}:${PROJECT_CONTAINER_BUILD_VERSION}";
+  if [[ "$PROJECT_CONTAINER_IMAGE_BUILD" != "0" ]]; then
+    echo "Building Docker image";
+    docker build --build-arg UID=${uid}                                \
+                 --build-arg GID=${gid}                                \
+                 --build-arg DWORKDIR="${workdir}"                     \
+                 --tag "$name_tag"                                     \
+                 --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-  if (( $? != 0 )); then
-    return $?;
+    if (( $? != 0 )); then
+      return $?;
+    fi
   fi
 
-  echo "Executing isolated $run_type";
-  docker run --name ${CONTAINER_BUILD_NAME}                        \
+  echo "Executing isolated $isolated_command";
+  docker run --name ${PROJECT_CONTAINER_BUILD_NAME}                \
              --mount type=bind,source="${PWD}",target="${workdir}" \
              --user ${uid}:${gid}                                  \
              --rm                                                  \
              --tty                                                 \
-             ${CONTAINER_BUILD_NAME}:${CONTAINER_BUILD_VERSION}    \
-             "$run_type"                                           \
+             --interactive                                         \
+             "$name_tag"                                           \
+             "$isolated_command"                                   \
              "$@";
 
-  return $?;
-}
-
-# Executes an isolated build process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's build.sh script
-#      to customise the build.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed build.sh script
-# is returned instead.
-#
-function run_isolated_build() {
-  _run_isolated "build" "$@";
-  return $?;
-}
-
-# Executes an isolated test process inside a Docker container.
-#
-# This function executes a 'docker build' followed by a 'docker run' command.
-# Returns the exit status of 'docker build', if it was not successful,
-# otherwise returns the exit status of 'docker run'.
-#
-# Args:
-# $@ - Arguments to be passed to the project's test.sh script
-#      to customise the test process.
-#
-# Returns:
-# The exit status of the Docker-related commands. If the Docker commands are
-# all successful, then the exit status of the executed test.sh script
-# is returned instead.
-#
-function run_isolated_tests() {
-  _run_isolated "tests" "$@";
   return $?;
 }

--- a/share/r/docker/controls.sh
+++ b/share/r/docker/controls.sh
@@ -74,8 +74,9 @@ function project_run_isolated() {
                  --tag "$name_tag"                                     \
                  --file .docker/${PROJECT_CONTAINER_BUILD_DOCKERFILE} .
 
-    if (( $? != 0 )); then
-      return $?;
+    local docker_status=$?;
+    if (( docker_status != 0 )); then
+      return $docker_status;
     fi
   fi
 

--- a/share/var/script_build_isolated_main
+++ b/share/var/script_build_isolated_main
@@ -1,5 +1,5 @@
 if [[ $ARG_ISOLATED == true ]]; then
   source ".docker/controls.sh";
-  run_isolated_build "${ARGS_ISOLATED[@]}";
+  project_run_isolated build "${ARGS_ISOLATED[@]}";
   exit $?;
 fi

--- a/share/var/script_test_isolated_main
+++ b/share/var/script_test_isolated_main
@@ -1,5 +1,5 @@
 if [[ $ARG_ISOLATED == true ]]; then
   source ".docker/controls.sh";
-  run_isolated_tests "${ARGS_ISOLATED[@]}";
+  project_run_isolated tests "${ARGS_ISOLATED[@]}";
   exit $?;
 fi


### PR DESCRIPTION
Introduces the standardised `project_run_isolated()` shell function.
Removes previously used analogous shell driver functions used by build and test scripts.
Introduces the standardised `PROJECT_CONTAINER_*` shell variables to control some aspects about project containers.
Introduces the `PROJECT_CONTAINER_IMAGE_BUILD` environment variable to allow users to skip the Docker image building.
Adds the `--interactive` argument to the `docker run` command to allow for interactive usage with dev containers from the command line.
