### PR TITLE
Fix Working Directory in Test Mode

### DIFF
--- a/tests/functionality_test_driver.sh
+++ b/tests/functionality_test_driver.sh
@@ -98,15 +98,6 @@ function main() {
   project_init_start "$@";
 
   if [[ $PROJECT_INIT_QUICKSTART_REQUESTED == true ]]; then
-    # Override the target directory for Quickstart output files
-    local qs_base="$TESTS_OUTPUT_DIR_QUICKSTART";
-    _PROJECT_INIT_QUICKSTART_OUTPUT_DIR="${qs_base}/${ARG_QUICKSTART_NAMES_NORM[0]}";
-    # Ensure output directory exists
-    if ! mkdir -p "${_PROJECT_INIT_QUICKSTART_OUTPUT_DIR}"; then
-      logE "Failed to create Quickstart test output directory:";
-      logE "at: '${_PROJECT_INIT_QUICKSTART_OUTPUT_DIR}'";
-      return $EXIT_FAILURE;
-    fi
     project_init_process_quickstart;
   else
     project_init_show_main_form;

--- a/tests/functionality_tests.sh
+++ b/tests/functionality_tests.sh
@@ -126,9 +126,9 @@ function _test_functionality_driver() {
       if (( $? != 0 )); then
         test_status=3;
       fi
-      _cd_or_die "$TESTPATH";
     fi
   fi
+  _cd_or_die "$TESTPATH";
 
   if (( test_status != 0 )); then
     echo -e "${LABEL_FAILED}\n";
@@ -253,6 +253,7 @@ function test_functionality_with() {
     ASSERT_FILE_PATH_PREFIX="${_FORM_ANSWERS[project.dir]}";
   fi
 
+  _cd_or_die "${TESTS_OUTPUT_DIR}";
   _test_functionality_driver "$title" "$config_file";
   return $?;
 }
@@ -325,6 +326,16 @@ function test_functionality_quickstart() {
   quickstart_name_norm=$(_normalise_quickstart_name "$quickstart_name");
 
   ASSERT_FILE_PATH_PREFIX="quickstart/${quickstart_name_norm}";
+
+  local quickstart_output_dir="${TESTS_OUTPUT_DIR_QUICKSTART}/${quickstart_name_norm}";
+
+  # Ensure output directory exists
+  if ! mkdir -p "$quickstart_output_dir"; then
+    logE "Failed to create Quickstart test output directory:";
+    logE "at: '${quickstart_output_dir}'";
+    return 7;
+  fi
+  _cd_or_die "$quickstart_output_dir";
 
   # Test run title
   quickstart_name="Quickstart function for $quickstart_name";


### PR DESCRIPTION
Changes the active working directory when in test mode, such that the `USER_CWD` variable should point to the respective test output directory, instead of the test path.

Moved the creation of the Quickstart test directory from the functionality driver script to the main `test_functionality_quickstart()` function.
