### PR TITLE
Add Standard Test Script for Node.js Server Application Template

### DIFF
--- a/js/02_server-nodejs/source/.docker/entrypoint.sh
+++ b/js/02_server-nodejs/source/.docker/entrypoint.sh
@@ -3,16 +3,16 @@
 #                                                                             #
 #                   The Entrypoint for the Docker Container                   #
 #                                                                             #
-# The (first) argument 'app' is handled in a special way. It is used to       #
-# launch the underlying project's run.sh script. All subsequent arguments     #
+# The (first) argument 'tests' is handled in a special way. It is used to     #
+# launch the underlying project's test.sh script. All subsequent arguments    #
 # are passed to that script transparently. If the first argument is           #
-# not 'app', then all arguments are passed to the exec command as is.         #
+# not 'tests', then all arguments are passed to the exec command as is.       #
 #                                                                             #
 ###############################################################################
 
-if [[ "$1" == "app" ]]; then
+if [[ "$1" == "tests" ]]; then
   shift;
-  exec ./run.sh "$@";
+  exec ./test.sh "$@";
 else
   exec "$@";
 fi

--- a/js/02_server-nodejs/source/test.sh
+++ b/js/02_server-nodejs/source/test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run script for the ${{VAR_PROJECT_NAME}} server application.
+# Test script for the ${{VAR_PROJECT_NAME}} server application.
 
-USAGE="Usage: run.sh [options]";
+USAGE="Usage: test.sh [options]";
 
 HELP_TEXT=$(cat << EOS
-Runs the ${{VAR_PROJECT_NAME}} server application.
+Tests the ${{VAR_PROJECT_NAME}} server application.
 
 ${USAGE}
 
@@ -34,7 +34,7 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGPARSE}}
     echo "Unknown argument: '$arg'";
     echo "$USAGE";
     echo "";
-    echo "Run 'run.sh --help' for more information";
+    echo "Run 'test.sh --help' for more information";
     exit 1;
     ;;
   esac

--- a/js/var/script_run_isolated_main
+++ b/js/var/script_run_isolated_main
@@ -1,5 +1,5 @@
 if [[ $ARG_ISOLATED == true ]]; then
   source ".docker/controls.sh";
-  project_run_isolated app "${ARGS_ISOLATED[@]}";
+  project_run_isolated tests "${ARGS_ISOLATED[@]}";
   exit $?;
 fi

--- a/tests/test_func_js_server-nodejs.sh
+++ b/tests/test_func_js_server-nodejs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2023 Raven Computing
+# Copyright (C) 2025 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ function test_functionality_result() {
   files+=("package.json");
   files+=("app.js");
   files+=("public/index.html");
-  files+=("run.sh");
+  files+=("test.sh");
   files+=(".docker/controls.sh");
   files+=(".docker/Dockerfile-run");
   files+=(".docker/entrypoint.sh");


### PR DESCRIPTION
Adds standard test script to _Node.js_ server application template.
Renames the _run.sh_ script to _test.sh_ and refactores existing project control code.