### PR TITLE
Add Check to Skip Directories

### DIFF
--- a/libinit.sh
+++ b/libinit.sh
@@ -4838,6 +4838,9 @@ function project_init_copyright_headers() {
   local _file="";
   local _file_ext="";
   for _file in "${CACHE_ALL_FILES[@]}"; do
+    if [ -d "${_file}" ]; then
+      continue;
+    fi
     _file="$(basename "${_file}")";
     _file_ext="${_file##*.}";
     if [[ "${_file_ext}" != "" && "${_file_ext}" != "${_file}" ]]; then


### PR DESCRIPTION
Adds a check in the `project_init_copyright_headers()` function to skip directories.
