### PR TITLE
Add Support for Sanitizers

### DIFF
--- a/cpp/01_executable/source/CMakeLists.txt
+++ b/cpp/01_executable/source/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Options
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS "Enable/disable tests" OFF)
+option(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS "Enable/disable the use of sanitizers" OFF)
 
 # Set CMAKE_PREFIX_PATH from file
 if(EXISTS "${PROJECT_SOURCE_DIR}/.cmakeprefixpath")
@@ -29,5 +30,7 @@ include(Dependencies.cmake)
 
 # Enable testing project-wide
 include(cmake/TestUtil.cmake)
+
+include(cmake/SanitizerUtil.cmake)
 
 add_subdirectory(src/main main)

--- a/cpp/01_executable/source/build.sh
+++ b/cpp/01_executable/source/build.sh
@@ -20,6 +20,8 @@ Options:
 ${{VAR_SCRIPT_BUILD_DOCS_OPT}}
 ${{VAR_SCRIPT_BUILD_ISOLATED_OPT}}
 
+  [--sanitizers]  Use sanitizers when building and running.
+
   [--skip-config] Skip the build configuration step. If the build tree does not
                   exist yet, then this option has no effect and the build
                   configuration step is executed.
@@ -36,6 +38,7 @@ ARG_CONFIG=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_DOCS_ARGFLAG}}
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
+ARG_SANITIZERS=false;
 ARG_SKIP_CONFIG=false;
 ARG_SKIP_TESTS=false;
 ARG_SHOW_HELP=false;
@@ -60,6 +63,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
 ${{VAR_SCRIPT_BUILD_DOCS_ARGPARSE}}
+    --sanitizers)
+    ARG_SANITIZERS=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
     --skip-config)
     ARG_SKIP_CONFIG=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
@@ -130,15 +138,20 @@ if [[ $ARG_DEBUG == true ]]; then
 fi
 
 BUILD_TESTS="ON";
+BUILD_WITH_SANITIZERS="OFF";
 
 if [[ $ARG_SKIP_TESTS == true ]]; then
   BUILD_TESTS="OFF";
+fi
+if [[ $ARG_SANITIZERS == true ]]; then
+  BUILD_WITH_SANITIZERS="ON";
 fi
 
 # CMake: Configure
 if [[ $ARG_SKIP_CONFIG == false ]]; then
   cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
-        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" ..;
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" ..;
 
   config_status=$?;
   if (( config_status != 0 )); then

--- a/cpp/01_executable/source/cmake/SanitizerUtil.cmake
+++ b/cpp/01_executable/source/cmake/SanitizerUtil.cmake
@@ -1,0 +1,1 @@
+${{INCLUDE:cpp/cmake/SanitizerUtil.cmake}}

--- a/cpp/01_executable/source/src/main/CMakeLists.txt
+++ b/cpp/01_executable/source/src/main/CMakeLists.txt
@@ -17,6 +17,13 @@ target_include_directories(
     cpp
 )
 
+if(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS)
+    add_sanitizers(
+        ${${{VAR_PROJECT_NAME_UPPER}}_TARGET_APPLICATION_CORE}
+        address leak undefined
+    )
+endif()
+
 #==================================[ TARGET ]==================================
 # Application ${{VAR_PROJECT_NAME}} main executable
 

--- a/cpp/01_executable/source/test.sh
+++ b/cpp/01_executable/source/test.sh
@@ -94,6 +94,9 @@ fi
 # in a terminal, we explicitly activate colourful output.
 export GTEST_COLOR=1;
 
+# UB-Sanitizer options.
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1";
+
 # Run tests with CTest
 ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
 exit $?;

--- a/share/cpp/cmake/SanitizerUtil.cmake
+++ b/share/cpp/cmake/SanitizerUtil.cmake
@@ -1,0 +1,82 @@
+# Copyright (C) 2025 Raven Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#==============================================================================
+#
+# Contains a function for adding compile and link options to targets in
+# CMake-based projects to add support for sanitizers, for example address
+# and memory leak sanitizers.
+# The minimum CMake version required by this code is v3.14.
+#
+#==============================================================================
+
+# Adds sanitizer support to a given CMake target.
+#
+# Appends the appropriate compiler and linker flags to enable the requested
+# sanitizers for the specified target.
+#
+# Arguments:
+#
+#   target_name:
+#       The name of the target to which sanitizers will be added.
+#       This argument is mandatory.
+#
+#   sanitizers:
+#       The types of sanitizers to enable. At least one sanitizer type must
+#       be specified. More than one can be specified by separating them
+#       with spaces. Supported sanitizers are: 'address', 'leak', 'undefined'.
+#
+# Usage:
+#   add_sanitizers(<target_name> <sanitizer1> [<sanitizer2> ...])
+#
+# Example:
+#   add_sanitizers(mytarget address leak undefined)
+#
+function(add_sanitizers target_name)
+    set(SAN_TARGET_NAME "${target_name}")
+    set(SAN_SANITIZERS ${ARGN})
+    set(SAN_COMPILE_FLAGS "")
+    set(SAN_LINK_FLAGS "")
+    set(SAN_COMPILER_ARG "-fsanitize")
+    set(SAN_LINKER_ARG "-fsanitize")
+
+    if("${SAN_SANITIZERS}" STREQUAL "")
+        message(
+            FATAL_ERROR
+            "No sanitizers specified for target ${SAN_TARGET_NAME}. "
+            "Please specify at least one sanitizer type."
+        )
+    endif()
+
+    foreach(SANITIZER_TYPE ${SAN_SANITIZERS})
+        if(SANITIZER_TYPE STREQUAL "address")
+            list(APPEND SAN_COMPILE_FLAGS "${SAN_COMPILER_ARG}=address")
+            list(APPEND SAN_LINK_FLAGS "${SAN_LINKER_ARG}=address")
+        elseif(SANITIZER_TYPE STREQUAL "leak")
+            list(APPEND SAN_COMPILE_FLAGS "${SAN_COMPILER_ARG}=leak")
+            list(APPEND SAN_LINK_FLAGS "${SAN_LINKER_ARG}=leak")
+        elseif(SANITIZER_TYPE STREQUAL "undefined")
+            list(APPEND SAN_COMPILE_FLAGS "${SAN_COMPILER_ARG}=undefined")
+            list(APPEND SAN_LINK_FLAGS "${SAN_LINKER_ARG}=undefined")
+        else()
+            message(FATAL_ERROR "Unsupported sanitizer type: ${SANITIZER_TYPE}")
+        endif()
+    endforeach()
+
+    list(APPEND SAN_COMPILE_FLAGS "-fno-omit-frame-pointer")
+
+    target_compile_options(${SAN_TARGET_NAME} PUBLIC ${SAN_COMPILE_FLAGS})
+    target_link_options(${SAN_TARGET_NAME} PUBLIC ${SAN_LINK_FLAGS})
+
+endfunction()


### PR DESCRIPTION
In _C_ and _C++_ project source templates, adds standard support for utilization of various sanitizers.

Adds the `--sanitizers` option to the build script in _C++_ executables project source template. Provides a _CMake_ function to add the corresponding compiler and linker flags to enable various sanitizers, e.g. a memory leak sanitizer.
