### PR TITLE
Add Standard Support for Test Coverage in C and C++ Projects

### DIFF
--- a/c/01_executable/source/CMakeLists.txt
+++ b/c/01_executable/source/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Options
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS "Enable/disable tests" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS "Enable/disable the use of sanitizers" OFF)
+option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE "Enable/disable test coverage instrumentation" OFF)
 
 # Set CMAKE_PREFIX_PATH from file
 if(EXISTS "${PROJECT_SOURCE_DIR}/.cmakeprefixpath")
@@ -31,6 +32,8 @@ include(Dependencies.cmake)
 
 # Enable testing project-wide
 include(cmake/TestUtil.cmake)
+
+include(cmake/TestCoverageUtil.cmake)
 
 include(cmake/SanitizerUtil.cmake)
 

--- a/c/01_executable/source/build.sh
+++ b/c/01_executable/source/build.sh
@@ -15,6 +15,8 @@ Options:
   [--config]      Only execute the build configuration step. This option will skip
                   the build step.
 
+  [--coverage]    Enable code coverage instrumentation. Should only be used with debug builds.
+
   [--debug]       Build the application with debug symbols and with
                   optimizations turned off.
 ${{VAR_SCRIPT_BUILD_DOCS_OPT}}
@@ -35,6 +37,7 @@ EOS
 # Arg flags
 ARG_CLEAN=false;
 ARG_CONFIG=false;
+ARG_COVERAGE=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_DOCS_ARGFLAG}}
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
@@ -54,6 +57,11 @@ for arg in "$@"; do
     ;;
     --config)
     ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --coverage)
+    ARG_COVERAGE=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -133,6 +141,7 @@ cd "build";
 
 BUILD_CONFIGURATION="Release";
 BUILD_WITH_SANITIZERS="OFF";
+BUILD_WITH_COVERAGE="OFF";
 
 if [[ $ARG_DEBUG == true ]]; then
   BUILD_CONFIGURATION="Debug";
@@ -146,12 +155,19 @@ fi
 if [[ $ARG_SANITIZERS == true ]]; then
   BUILD_WITH_SANITIZERS="ON";
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  BUILD_WITH_COVERAGE="ON";
+  if [[ $ARG_SKIP_TESTS == true ]]; then
+    echo "Warning: Unable to automatically generate test coverage reports when not building tests";
+  fi
+fi
 
 # CMake: Configure
 if [[ $ARG_SKIP_CONFIG == false ]]; then
   cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
-        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" ..;
+        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE="$BUILD_WITH_COVERAGE" ..;
 
   config_status=$?;
   if (( config_status != 0 )); then

--- a/c/01_executable/source/cmake/TestCoverageUtil.cmake
+++ b/c/01_executable/source/cmake/TestCoverageUtil.cmake
@@ -1,0 +1,1 @@
+${{INCLUDE:c/cmake/TestCoverageUtil.cmake}}

--- a/c/01_executable/source/src/main/CMakeLists.txt
+++ b/c/01_executable/source/src/main/CMakeLists.txt
@@ -47,4 +47,7 @@ target_link_libraries(
 
 if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS)
     add_subdirectory(tests)
+    if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE)
+        add_code_coverage(${${{VAR_PROJECT_NAME_UPPER}}_TARGET_APPLICATION_CORE})
+    endif()
 endif()

--- a/c/01_executable/source/test.sh
+++ b/c/01_executable/source/test.sh
@@ -9,6 +9,8 @@ Tests the ${{VAR_PROJECT_NAME}} application.
 ${USAGE}
 
 Options:
+
+  [--coverage] Report code coverage metrics for the test runs.
 ${{VAR_SCRIPT_TEST_ISOLATED_OPT}}
 
   [-?|--help]  Show this help message.
@@ -16,6 +18,7 @@ EOS
 )
 
 # Arg flags
+ARG_COVERAGE=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
 ARG_SHOW_HELP=false;
 
@@ -24,6 +27,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY}}
 # Parse all arguments given to this script
 for arg in "$@"; do
   case $arg in
+    --coverage)
+    ARG_COVERAGE=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGPARSE}}
     -\?|--help)
     ARG_SHOW_HELP=true;
@@ -66,6 +74,16 @@ if ! command -v "ctest" &> /dev/null; then
   echo "ERROR: Please make sure that CMake and CTest are correctly installed";
   exit 1;
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  if ! command -v "lcov" &> /dev/null; then
+    echo "ERROR: Could not find command 'lcov' to generate test coverage data";
+    exit 1;
+  fi
+  if ! command -v "genhtml" &> /dev/null; then
+    echo "ERROR: Could not find command 'genhtml' to generate test coverage report";
+    exit 1;
+  fi
+fi
 
 # Check if the build dir is empty
 if [ -z "$(ls -A build)" ]; then
@@ -75,6 +93,17 @@ if [ -z "$(ls -A build)" ]; then
   if (( $? != 0 )); then
     exit $?;
   fi
+fi
+
+COV_INCL_PATH="$PWD";
+BUILD_DIR_COV_DATA="cov";
+FILE_COV_DATA_MERGED="merged.info";
+BUILD_DIR_COV_REPORT="coverage_report";
+
+if [[ $ARG_COVERAGE == true ]]; then
+  # Remove previously collected test coverage data
+  rm -rf "build/${BUILD_DIR_COV_DATA}" "build/${BUILD_DIR_COV_REPORT}";
+  find . -name '*.gcda' -delete;
 fi
 
 cd "build";
@@ -94,4 +123,41 @@ export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1";
 
 # Run tests with CTest
 ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
-exit $?;
+ctest_status=$?;
+
+if (( ctest_status == 0 )); then
+  if [[ $ARG_COVERAGE == true ]]; then
+    echo "Collecting coverage data";
+    mkdir "$BUILD_DIR_COV_DATA";
+    if ! lcov --quiet --directory . --capture \
+              --include "${COV_INCL_PATH}"'/src/*' \
+              --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to collect test coverage data";
+      exit 1;
+    fi
+    echo "Generating test coverage report";
+    genhtml_opt_args=();
+    genhtml_version=($(genhtml --version |grep -o -e '[0-9.]'));
+    genhtml_version="${lcov_version[0]}";
+    if (( genhtml_version >= 2 )); then
+      genhtml_opt_args+=("--header-title");
+      genhtml_opt_args+=("${{VAR_PROJECT_NAME}} Test Coverage");
+      genhtml_opt_args+=("--footer");
+      genhtml_opt_args+=("Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}");
+    fi
+    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" \
+                 --prefix "$COV_INCL_PATH" \
+                 --title "${{VAR_PROJECT_NAME}} Test Coverage" \
+                 "${genhtml_opt_args[@]}" \
+                 "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to generate test coverage report";
+      exit 1;
+    fi
+    report_label="build/${BUILD_DIR_COV_REPORT}/index.html";
+    report_url="file://${COV_INCL_PATH}/${report_label}";
+    report_link="\e]8;;${report_url}\e\\\\${report_label}\e]8;;\e\\\\";
+    echo -e "Wrote HTML report to $report_link";
+  fi
+fi
+
+exit $ctest_status;

--- a/c/02_library/source/CMakeLists.txt
+++ b/c/02_library/source/CMakeLists.txt
@@ -15,6 +15,7 @@ project(
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS "Enable/disable tests" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS "Enable/disable the use of sanitizers" OFF)
+option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE "Enable/disable test coverage instrumentation" OFF)
 
 # Set CMAKE_PREFIX_PATH from file
 if(EXISTS "${PROJECT_SOURCE_DIR}/.cmakeprefixpath")
@@ -28,6 +29,8 @@ include(Dependencies.cmake)
 
 # Enable testing project-wide
 include(cmake/TestUtil.cmake)
+
+include(cmake/TestCoverageUtil.cmake)
 
 include(cmake/SanitizerUtil.cmake)
 

--- a/c/02_library/source/build.sh
+++ b/c/02_library/source/build.sh
@@ -15,6 +15,8 @@ Options:
   [--config]      Only execute the build configuration step. This option will skip
                   the build step.
 
+  [--coverage]    Enable code coverage instrumentation. Should only be used with debug builds.
+
   [--debug]       Build the libraries with debug symbols and with
                   optimizations turned off.
 ${{VAR_SCRIPT_BUILD_DOCS_OPT}}
@@ -37,6 +39,7 @@ EOS
 # Arg flags
 ARG_CLEAN=false;
 ARG_CONFIG=false;
+ARG_COVERAGE=false;
 ARG_SANITIZERS=false;
 ARG_SHARED=false;
 ARG_DEBUG=false;
@@ -57,6 +60,11 @@ for arg in "$@"; do
     ;;
     --config)
     ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --coverage)
+    ARG_COVERAGE=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -147,6 +155,7 @@ fi
 
 BUILD_TESTS="ON";
 BUILD_WITH_SANITIZERS="OFF";
+BUILD_WITH_COVERAGE="OFF";
 
 if [[ $ARG_SKIP_TESTS == true ]]; then
   BUILD_TESTS="OFF";
@@ -160,13 +169,20 @@ BUILD_SHARED_LIBS="OFF";
 if [[ $ARG_SHARED == true ]]; then
   BUILD_SHARED_LIBS="ON";
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  BUILD_WITH_COVERAGE="ON";
+  if [[ $ARG_SKIP_TESTS == true ]]; then
+    echo "Warning: Unable to automatically generate test coverage reports when not building tests";
+  fi
+fi
 
 # CMake: Configure
 if [[ $ARG_SKIP_CONFIG == false ]]; then
   cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" \
-        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" .. ;
+        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE="$BUILD_WITH_COVERAGE" ..;
 
   config_status=$?;
   if (( config_status != 0 )); then

--- a/c/02_library/source/cmake/TestCoverageUtil.cmake
+++ b/c/02_library/source/cmake/TestCoverageUtil.cmake
@@ -1,0 +1,1 @@
+${{INCLUDE:c/cmake/TestCoverageUtil.cmake}}

--- a/c/02_library/source/src/main/CMakeLists.txt
+++ b/c/02_library/source/src/main/CMakeLists.txt
@@ -64,4 +64,7 @@ endif()
 
 if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS)
     add_subdirectory(tests)
+    if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE)
+        add_code_coverage(${${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN})
+    endif()
 endif()

--- a/c/02_library/source/test.sh
+++ b/c/02_library/source/test.sh
@@ -9,6 +9,8 @@ Tests the ${{VAR_PROJECT_NAME}} library.
 ${USAGE}
 
 Options:
+
+  [--coverage] Report code coverage metrics for the test runs.
 ${{VAR_SCRIPT_TEST_ISOLATED_OPT}}
 
   [-?|--help]  Show this help message.
@@ -16,6 +18,7 @@ EOS
 )
 
 # Arg flags
+ARG_COVERAGE=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
 ARG_SHOW_HELP=false;
 
@@ -24,6 +27,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY}}
 # Parse all arguments given to this script
 for arg in "$@"; do
   case $arg in
+    --coverage)
+    ARG_COVERAGE=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGPARSE}}
     -\?|--help)
     ARG_SHOW_HELP=true;
@@ -66,6 +74,16 @@ if ! command -v "ctest" &> /dev/null; then
   echo "ERROR: Please make sure that CMake and CTest are correctly installed";
   exit 1;
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  if ! command -v "lcov" &> /dev/null; then
+    echo "ERROR: Could not find command 'lcov' to generate test coverage data";
+    exit 1;
+  fi
+  if ! command -v "genhtml" &> /dev/null; then
+    echo "ERROR: Could not find command 'genhtml' to generate test coverage report";
+    exit 1;
+  fi
+fi
 
 # Check if the build dir is empty
 if [ -z "$(ls -A build)" ]; then
@@ -75,6 +93,17 @@ if [ -z "$(ls -A build)" ]; then
   if (( $? != 0 )); then
     exit $?;
   fi
+fi
+
+COV_INCL_PATH="$PWD";
+BUILD_DIR_COV_DATA="cov";
+FILE_COV_DATA_MERGED="merged.info";
+BUILD_DIR_COV_REPORT="coverage_report";
+
+if [[ $ARG_COVERAGE == true ]]; then
+  # Remove previously collected test coverage data
+  rm -rf "build/${BUILD_DIR_COV_DATA}" "build/${BUILD_DIR_COV_REPORT}";
+  find . -name '*.gcda' -delete;
 fi
 
 cd "build";
@@ -94,4 +123,41 @@ export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1";
 
 # Run tests with CTest
 ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
-exit $?;
+ctest_status=$?;
+
+if (( ctest_status == 0 )); then
+  if [[ $ARG_COVERAGE == true ]]; then
+    echo "Collecting coverage data";
+    mkdir "$BUILD_DIR_COV_DATA";
+    if ! lcov --quiet --directory . --capture \
+              --include "${COV_INCL_PATH}"'/src/*' \
+              --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to collect test coverage data";
+      exit 1;
+    fi
+    echo "Generating test coverage report";
+    genhtml_opt_args=();
+    genhtml_version=($(genhtml --version |grep -o -e '[0-9.]'));
+    genhtml_version="${genhtml_version[0]}";
+    if (( genhtml_version >= 2 )); then
+      genhtml_opt_args+=("--header-title");
+      genhtml_opt_args+=("${{VAR_PROJECT_NAME}} Test Coverage");
+      genhtml_opt_args+=("--footer");
+      genhtml_opt_args+=("Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}");
+    fi
+    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" \
+                 --prefix "$COV_INCL_PATH" \
+                 --title "${{VAR_PROJECT_NAME}} Test Coverage" \
+                 "${genhtml_opt_args[@]}" \
+                 "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to generate test coverage report";
+      exit 1;
+    fi
+    report_label="build/${BUILD_DIR_COV_REPORT}/index.html";
+    report_url="file://${COV_INCL_PATH}/${report_label}";
+    report_link="\e]8;;${report_url}\e\\\\${report_label}\e]8;;\e\\\\";
+    echo -e "Wrote HTML report to $report_link";
+  fi
+fi
+
+exit $ctest_status;

--- a/cpp/01_executable/source/CMakeLists.txt
+++ b/cpp/01_executable/source/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Options
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS "Enable/disable tests" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS "Enable/disable the use of sanitizers" OFF)
+option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE "Enable/disable test coverage instrumentation" OFF)
 
 # Set CMAKE_PREFIX_PATH from file
 if(EXISTS "${PROJECT_SOURCE_DIR}/.cmakeprefixpath")
@@ -30,6 +31,8 @@ include(Dependencies.cmake)
 
 # Enable testing project-wide
 include(cmake/TestUtil.cmake)
+
+include(cmake/TestCoverageUtil.cmake)
 
 include(cmake/SanitizerUtil.cmake)
 

--- a/cpp/01_executable/source/build.sh
+++ b/cpp/01_executable/source/build.sh
@@ -157,6 +157,9 @@ if [[ $ARG_SANITIZERS == true ]]; then
 fi
 if [[ $ARG_COVERAGE == true ]]; then
   BUILD_WITH_COVERAGE="ON";
+  if [[ $ARG_SKIP_TESTS == true ]]; then
+    echo "Warning: Unable to automatically generate test coverage reports when not building tests";
+  fi
 fi
 
 # CMake: Configure

--- a/cpp/01_executable/source/build.sh
+++ b/cpp/01_executable/source/build.sh
@@ -15,6 +15,8 @@ Options:
   [--config]      Only execute the build configuration step. This option will skip
                   the build step.
 
+  [--coverage]    Enable code coverage instrumentation. Should only be used with debug builds.
+
   [--debug]       Build the application with debug symbols and with
                   optimizations turned off.
 ${{VAR_SCRIPT_BUILD_DOCS_OPT}}
@@ -35,6 +37,7 @@ EOS
 # Arg flags
 ARG_CLEAN=false;
 ARG_CONFIG=false;
+ARG_COVERAGE=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_DOCS_ARGFLAG}}
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
@@ -54,6 +57,11 @@ for arg in "$@"; do
     ;;
     --config)
     ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --coverage)
+    ARG_COVERAGE=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -139,6 +147,7 @@ fi
 
 BUILD_TESTS="ON";
 BUILD_WITH_SANITIZERS="OFF";
+BUILD_WITH_COVERAGE="OFF";
 
 if [[ $ARG_SKIP_TESTS == true ]]; then
   BUILD_TESTS="OFF";
@@ -146,12 +155,16 @@ fi
 if [[ $ARG_SANITIZERS == true ]]; then
   BUILD_WITH_SANITIZERS="ON";
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  BUILD_WITH_COVERAGE="ON";
+fi
 
 # CMake: Configure
 if [[ $ARG_SKIP_CONFIG == false ]]; then
   cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
-        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" ..;
+        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE="$BUILD_WITH_COVERAGE" ..;
 
   config_status=$?;
   if (( config_status != 0 )); then

--- a/cpp/01_executable/source/cmake/TestCoverageUtil.cmake
+++ b/cpp/01_executable/source/cmake/TestCoverageUtil.cmake
@@ -1,0 +1,1 @@
+${{INCLUDE:c/cmake/TestCoverageUtil.cmake}}

--- a/cpp/01_executable/source/src/main/CMakeLists.txt
+++ b/cpp/01_executable/source/src/main/CMakeLists.txt
@@ -47,4 +47,7 @@ target_link_libraries(
 
 if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS)
     add_subdirectory(tests)
+    if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE)
+        add_code_coverage(${${{VAR_PROJECT_NAME_UPPER}}_TARGET_APPLICATION_CORE})
+    endif()
 endif()

--- a/cpp/01_executable/source/test.sh
+++ b/cpp/01_executable/source/test.sh
@@ -10,7 +10,7 @@ ${USAGE}
 
 Options:
 
-  [--coverage] Measure and report code coverage metrics for the test runs.
+  [--coverage] Report code coverage metrics for the test runs.
 ${{VAR_SCRIPT_TEST_ISOLATED_OPT}}
 
   [-?|--help]  Show this help message.
@@ -96,10 +96,13 @@ if [ -z "$(ls -A build)" ]; then
 fi
 
 COV_INCL_PATH="$PWD";
+BUILD_DIR_COV_DATA="cov";
+FILE_COV_DATA_MERGED="merged.info";
+BUILD_DIR_COV_REPORT="coverage_report";
 
 if [[ $ARG_COVERAGE == true ]]; then
   # Remove previously collected test coverage data
-  rm -rf "build/ccov/*.info" "build/coverage_report";
+  rm -rf "build/${BUILD_DIR_COV_DATA}" "build/${BUILD_DIR_COV_REPORT}";
   find . -name '*.gcda' -delete;
 fi
 
@@ -130,16 +133,17 @@ ctest_status=$?;
 if (( ctest_status == 0 )); then
   if [[ $ARG_COVERAGE == true ]]; then
     echo "Collecting coverage data";
-    if ! lcov --quiet --directory . --capture --include "${COV_INCL_PATH}"'/src/*' --output-file "ccov/merged.info"; then
+    mkdir "$BUILD_DIR_COV_DATA";
+    if ! lcov --quiet --directory . --capture --include "${COV_INCL_PATH}"'/src/*' --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
       echo "Failed to collect test coverage data";
       exit 1;
     fi
     echo "Generating test coverage report";
-    if ! genhtml --quiet --output-directory "coverage_report" --prefix "$COV_INCL_PATH" --title "${{VAR_PROJECT_NAME}} Test Coverage" "ccov/merged.info"; then
+    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" --prefix "$COV_INCL_PATH" --title "${{VAR_PROJECT_NAME}} Test Coverage" "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
       echo "Failed to generate test coverage report";
       exit 1;
     fi
-    report_label="build/coverage_report/index.html";
+    report_label="build/${BUILD_DIR_COV_REPORT}/index.html";
     report_url="file://${COV_INCL_PATH}/${report_label}";
     report_link="\e]8;;${report_url}\e\\\\${report_label}\e]8;;\e\\\\";
     echo -e "Wrote HTML report to $report_link";

--- a/cpp/01_executable/source/test.sh
+++ b/cpp/01_executable/source/test.sh
@@ -134,12 +134,19 @@ if (( ctest_status == 0 )); then
   if [[ $ARG_COVERAGE == true ]]; then
     echo "Collecting coverage data";
     mkdir "$BUILD_DIR_COV_DATA";
-    if ! lcov --quiet --directory . --capture --include "${COV_INCL_PATH}"'/src/*' --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+    if ! lcov --quiet --directory . --capture \
+              --include "${COV_INCL_PATH}"'/src/*' \
+              --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
       echo "Failed to collect test coverage data";
       exit 1;
     fi
     echo "Generating test coverage report";
-    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" --prefix "$COV_INCL_PATH" --title "${{VAR_PROJECT_NAME}} Test Coverage" "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" \
+                 --prefix "$COV_INCL_PATH" \
+                 --title "${{VAR_PROJECT_NAME}} Test Coverage" \
+                 --header-title "${{VAR_PROJECT_NAME}} Test Coverage" \
+                 --footer "Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}" \
+                 "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
       echo "Failed to generate test coverage report";
       exit 1;
     fi

--- a/cpp/01_executable/source/test.sh
+++ b/cpp/01_executable/source/test.sh
@@ -141,11 +141,19 @@ if (( ctest_status == 0 )); then
       exit 1;
     fi
     echo "Generating test coverage report";
+    genhtml_opt_args=();
+    genhtml_version=($(genhtml --version |grep -o -e '[0-9.]'));
+    genhtml_version="${genhtml_version[0]}";
+    if (( genhtml_version >= 2 )); then
+      genhtml_opt_args+=("--header-title");
+      genhtml_opt_args+=("${{VAR_PROJECT_NAME}} Test Coverage");
+      genhtml_opt_args+=("--footer");
+      genhtml_opt_args+=("Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}");
+    fi
     if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" \
                  --prefix "$COV_INCL_PATH" \
                  --title "${{VAR_PROJECT_NAME}} Test Coverage" \
-                 --header-title "${{VAR_PROJECT_NAME}} Test Coverage" \
-                 --footer "Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}" \
+                 "${genhtml_opt_args[@]}" \
                  "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
       echo "Failed to generate test coverage report";
       exit 1;

--- a/cpp/02_library/source/CMakeLists.txt
+++ b/cpp/02_library/source/CMakeLists.txt
@@ -14,6 +14,7 @@ project(
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS "Enable/disable tests" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS "Enable/disable the use of sanitizers" OFF)
+option(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE "Enable/disable test coverage instrumentation" OFF)
 
 # Set CMAKE_PREFIX_PATH from file
 if(EXISTS "${PROJECT_SOURCE_DIR}/.cmakeprefixpath")
@@ -27,6 +28,8 @@ include(Dependencies.cmake)
 
 # Enable testing project-wide
 include(cmake/TestUtil.cmake)
+
+include(cmake/TestCoverageUtil.cmake)
 
 include(cmake/SanitizerUtil.cmake)
 

--- a/cpp/02_library/source/build.sh
+++ b/cpp/02_library/source/build.sh
@@ -15,6 +15,8 @@ Options:
   [--config]      Only execute the build configuration step. This option will skip
                   the build step.
 
+  [--coverage]    Enable code coverage instrumentation. Should only be used with debug builds.
+
   [--debug]       Build the libraries with debug symbols and with
                   optimizations turned off.
 ${{VAR_SCRIPT_BUILD_DOCS_OPT}}
@@ -37,6 +39,7 @@ EOS
 # Arg flags
 ARG_CLEAN=false;
 ARG_CONFIG=false;
+ARG_COVERAGE=false;
 ARG_SHARED=false;
 ARG_DEBUG=false;
 ${{VAR_SCRIPT_BUILD_DOCS_ARGFLAG}}
@@ -57,6 +60,11 @@ for arg in "$@"; do
     ;;
     --config)
     ARG_CONFIG=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
+    --coverage)
+    ARG_COVERAGE=true;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
     shift
     ;;
@@ -147,12 +155,19 @@ fi
 
 BUILD_TESTS="ON";
 BUILD_WITH_SANITIZERS="OFF";
+BUILD_WITH_COVERAGE="OFF";
 
 if [[ $ARG_SKIP_TESTS == true ]]; then
   BUILD_TESTS="OFF";
 fi
 if [[ $ARG_SANITIZERS == true ]]; then
   BUILD_WITH_SANITIZERS="ON";
+fi
+if [[ $ARG_COVERAGE == true ]]; then
+  BUILD_WITH_COVERAGE="ON";
+  if [[ $ARG_SKIP_TESTS == true ]]; then
+    echo "Warning: Unable to automatically generate test coverage reports when not building tests";
+  fi
 fi
 
 BUILD_SHARED_LIBS="OFF";
@@ -166,7 +181,8 @@ if [[ $ARG_SKIP_CONFIG == false ]]; then
   cmake -DCMAKE_BUILD_TYPE="$BUILD_CONFIGURATION" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS="$BUILD_TESTS" \
         -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" \
-        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" .. ;
+        -D${{VAR_PROJECT_NAME_UPPER}}_USE_SANITIZERS="$BUILD_WITH_SANITIZERS" \
+        -D${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE="$BUILD_WITH_COVERAGE" ..;
 
   config_status=$?;
   if (( config_status != 0 )); then

--- a/cpp/02_library/source/cmake/TestCoverageUtil.cmake
+++ b/cpp/02_library/source/cmake/TestCoverageUtil.cmake
@@ -1,0 +1,1 @@
+${{INCLUDE:c/cmake/TestCoverageUtil.cmake}}

--- a/cpp/02_library/source/src/main/CMakeLists.txt
+++ b/cpp/02_library/source/src/main/CMakeLists.txt
@@ -64,4 +64,7 @@ endif()
 
 if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TESTS)
     add_subdirectory(tests)
+    if(${{VAR_PROJECT_NAME_UPPER}}_BUILD_TEST_COVERAGE)
+        add_code_coverage(${${{VAR_PROJECT_NAME_UPPER}}_TARGET_LIB_MAIN})
+    endif()
 endif()

--- a/cpp/02_library/source/test.sh
+++ b/cpp/02_library/source/test.sh
@@ -9,6 +9,8 @@ Tests the ${{VAR_PROJECT_NAME}} library.
 ${USAGE}
 
 Options:
+
+  [--coverage] Report code coverage metrics for the test runs.
 ${{VAR_SCRIPT_TEST_ISOLATED_OPT}}
 
   [-?|--help]  Show this help message.
@@ -16,6 +18,7 @@ EOS
 )
 
 # Arg flags
+ARG_COVERAGE=false;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGFLAG}}
 ARG_SHOW_HELP=false;
 
@@ -24,6 +27,11 @@ ${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY}}
 # Parse all arguments given to this script
 for arg in "$@"; do
   case $arg in
+    --coverage)
+    ARG_COVERAGE=true;
+${{VAR_SCRIPT_BUILD_ISOLATED_ARGARRAY_ADD}}
+    shift
+    ;;
 ${{VAR_SCRIPT_BUILD_ISOLATED_ARGPARSE}}
     -\?|--help)
     ARG_SHOW_HELP=true;
@@ -66,6 +74,16 @@ if ! command -v "ctest" &> /dev/null; then
   echo "ERROR: Please make sure that CMake and CTest are correctly installed";
   exit 1;
 fi
+if [[ $ARG_COVERAGE == true ]]; then
+  if ! command -v "lcov" &> /dev/null; then
+    echo "ERROR: Could not find command 'lcov' to generate test coverage data";
+    exit 1;
+  fi
+  if ! command -v "genhtml" &> /dev/null; then
+    echo "ERROR: Could not find command 'genhtml' to generate test coverage report";
+    exit 1;
+  fi
+fi
 
 # Check if the build dir is empty
 if [ -z "$(ls -A build)" ]; then
@@ -75,6 +93,17 @@ if [ -z "$(ls -A build)" ]; then
   if (( $? != 0 )); then
     exit $?;
   fi
+fi
+
+COV_INCL_PATH="$PWD";
+BUILD_DIR_COV_DATA="cov";
+FILE_COV_DATA_MERGED="merged.info";
+BUILD_DIR_COV_REPORT="coverage_report";
+
+if [[ $ARG_COVERAGE == true ]]; then
+  # Remove previously collected test coverage data
+  rm -rf "build/${BUILD_DIR_COV_DATA}" "build/${BUILD_DIR_COV_REPORT}";
+  find . -name '*.gcda' -delete;
 fi
 
 cd "build";
@@ -99,4 +128,41 @@ export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1";
 
 # Run tests with CTest
 ctest --output-on-failure --build-config "$BUILD_CONFIGURATION";
-exit $?;
+ctest_status=$?;
+
+if (( ctest_status == 0 )); then
+  if [[ $ARG_COVERAGE == true ]]; then
+    echo "Collecting coverage data";
+    mkdir "$BUILD_DIR_COV_DATA";
+    if ! lcov --quiet --directory . --capture \
+              --include "${COV_INCL_PATH}"'/src/*' \
+              --output-file "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to collect test coverage data";
+      exit 1;
+    fi
+    echo "Generating test coverage report";
+    genhtml_opt_args=();
+    genhtml_version=($(genhtml --version |grep -o -e '[0-9.]'));
+    genhtml_version="${genhtml_version[0]}";
+    if (( genhtml_version >= 2 )); then
+      genhtml_opt_args+=("--header-title");
+      genhtml_opt_args+=("${{VAR_PROJECT_NAME}} Test Coverage");
+      genhtml_opt_args+=("--footer");
+      genhtml_opt_args+=("Copyright © ${{VAR_COPYRIGHT_YEAR}} ${{VAR_PROJECT_ORGANISATION_NAME}}");
+    fi
+    if ! genhtml --quiet --output-directory "$BUILD_DIR_COV_REPORT" \
+                 --prefix "$COV_INCL_PATH" \
+                 --title "${{VAR_PROJECT_NAME}} Test Coverage" \
+                 "${genhtml_opt_args[@]}" \
+                 "${BUILD_DIR_COV_DATA}/${FILE_COV_DATA_MERGED}"; then
+      echo "Failed to generate test coverage report";
+      exit 1;
+    fi
+    report_label="build/${BUILD_DIR_COV_REPORT}/index.html";
+    report_url="file://${COV_INCL_PATH}/${report_label}";
+    report_link="\e]8;;${report_url}\e\\\\${report_label}\e]8;;\e\\\\";
+    echo -e "Wrote HTML report to $report_link";
+  fi
+fi
+
+exit $ctest_status;

--- a/share/c/cmake/TestCoverageUtil.cmake
+++ b/share/c/cmake/TestCoverageUtil.cmake
@@ -1,0 +1,61 @@
+# Copyright (C) 2025 Raven Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#==============================================================================
+#
+# Contains a function for adding compiler options to targets in CMake-based
+# projects to add support for code test coverage instrumentation.
+# The minimum CMake version required by this code is v3.14.
+#
+#==============================================================================
+
+# Adds code test coverage support to a given CMake target.
+#
+# Appends the appropriate compiler flags to enable code test
+# coverage instrumentation for the specified target.
+# Code coverage should only be enabled for Debug builds.
+#
+# Arguments:
+#
+#   target_name:
+#       The name of the target to which code coverage support will be added.
+#       This argument is mandatory.
+#
+# Example:
+#   add_code_coverage(mytarget)
+#
+function(add_code_coverage target_name)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} PROJECT_BUILD_TYPE)
+    message(STATUS "Adding code coverage instrumentation to target ${target_name}")
+    if(NOT ${PROJECT_BUILD_TYPE} STREQUAL "DEBUG")
+        message(
+            WARNING
+            "Code test coverage measurements should only be performed "
+            "with a non-optimized Debug build"
+        )
+    endif()
+
+    target_compile_options(
+        ${target_name}
+        PRIVATE
+        -ftest-coverage -fprofile-arcs -fno-default-inline
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-elide-constructors>
+    )
+    target_link_libraries(
+        ${target_name}
+        PRIVATE
+        gcov
+    )
+
+endfunction()

--- a/share/c/cmake/TestCoverageUtil.cmake
+++ b/share/c/cmake/TestCoverageUtil.cmake
@@ -47,7 +47,8 @@ function(add_code_coverage target_name)
         return()
     endif()
     if(MSYS)
-        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+           OR NOT CMAKE_C_COMPILER_ID STREQUAL "GNU")
             message(
                 WARNING
                 "When building with code test coverage support on Windows "

--- a/share/c/cmake/TestCoverageUtil.cmake
+++ b/share/c/cmake/TestCoverageUtil.cmake
@@ -36,6 +36,27 @@
 #   add_code_coverage(mytarget)
 #
 function(add_code_coverage target_name)
+    if(WIN32 AND CMAKE_GENERATOR MATCHES "^Visual Studio")
+        message(
+            WARNING
+            "Building with code test coverage support is not available "
+            "on Windows with the Visual Studio generator. If you want to "
+            "enable the use of code coverage metrics on Windows, please build "
+            "with GCC through MSYS2/MinGW."
+        )
+        return()
+    endif()
+    if(MSYS)
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            message(
+                WARNING
+                "When building with code test coverage support on Windows "
+                "with MSYS2/MinGW, GCC must be used as the compiler."
+            )
+            return()
+        endif()
+    endif()
+
     string(TOUPPER ${CMAKE_BUILD_TYPE} PROJECT_BUILD_TYPE)
     message(STATUS "Adding code coverage instrumentation to target ${target_name}")
     if(NOT ${PROJECT_BUILD_TYPE} STREQUAL "DEBUG")

--- a/share/c/docker/Dockerfile-build
+++ b/share/c/docker/Dockerfile-build
@@ -20,7 +20,8 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install \
  build-essential \
  wget \
  git \
- ca-certificates
+ ca-certificates \
+ lcov
 
 # Install CMake
 RUN wget -q -O /opt/cmake-installer.sh \

--- a/share/cpp/docker/Dockerfile-build
+++ b/share/cpp/docker/Dockerfile-build
@@ -20,7 +20,8 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install \
  build-essential \
  wget \
  git \
- ca-certificates
+ ca-certificates \
+ lcov
 
 # Install CMake
 RUN wget -q -O /opt/cmake-installer.sh \


### PR DESCRIPTION
Adds the `--coverage` option in build and test scripts for C and C++ project source templates.