### PR TITLE
Fix Wrong Line Content Comparisons When Erasing Blank Variables

### DIFF
--- a/libinit.sh
+++ b/libinit.sh
@@ -4696,7 +4696,10 @@ function replace_var() {
     # value is empty. Otherwise the handled file would contain
     # additional blank lines.
     if [ -z "${_var_value}" ]; then
-      # Find all line numbers of lines containing the given variable key
+      # Find all line numbers of lines containing the given variable key.
+      # As we iterate over the found lines and potentially remove blank ones,
+      # effective line numbers of subsequent lines are offset by one. Therefore,
+      # for every removed line the offset is incremented by one to account for that.
       local line_offset=0;
       # shellcheck disable=SC2013
       for line_num in $(grep -n "\${{VAR_${_var_key}}}" "$f" \

--- a/libinit.sh
+++ b/libinit.sh
@@ -4697,8 +4697,8 @@ function replace_var() {
     # additional blank lines.
     if [ -z "${_var_value}" ]; then
       # Find all line numbers of lines containing the given variable key
-      # shellcheck disable=SC2013
       local line_offset=0;
+      # shellcheck disable=SC2013
       for line_num in $(grep -n "\${{VAR_${_var_key}}}" "$f" \
                           |awk -F  ":" '{print $1}'); do
 

--- a/libinit.sh
+++ b/libinit.sh
@@ -4698,11 +4698,13 @@ function replace_var() {
     if [ -z "${_var_value}" ]; then
       # Find all line numbers of lines containing the given variable key
       # shellcheck disable=SC2013
+      local line_offset=0;
       for line_num in $(grep -n "\${{VAR_${_var_key}}}" "$f" \
                           |awk -F  ":" '{print $1}'); do
 
         # Get the line text and trim leading and trailing whitespaces
         local line="";
+        line_num=$((line_num - line_offset));
         line="$(sed -n "${line_num}p" < "$f" |xargs)";
         if [[ "$line" == "\${{VAR_${_var_key}}}" ]]; then
           # The line only contains the given variable key
@@ -4712,6 +4714,7 @@ function replace_var() {
           removed="$(awk 'NR!~/^('"$line_num"')$/' "$f")";
           # Overwrite the source file
           echo "$removed" > "$f";
+          ((++line_offset));
         fi
       done
     fi


### PR DESCRIPTION
When a source template file contains the same substitution variable multiple times on different lines and is erased with a call to `replace_var()` with an empty value argument, then the entire line should be removed if the variable is the only content of that line. The line numbers for the variable locations is computed once with _grep_ and then looped over. However, as the file content is changed in every iteration if all lines contain only the variable itself, which should be erased, then the line numbers after the first occurrence are wrong since the lines are shifted by then. Comparing different lines might result in the effect that the line is not considered empty and thus not completely erased.

This fix adds the correct line offset computation to always check the content of the line containing the substitution variable.
