### PR TITLE
Add Handling for CMake Policy CMP0135

### DIFF
--- a/share/c/cmake/DependencyUtil.cmake
+++ b/share/c/cmake/DependencyUtil.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Raven Computing
+# Copyright (C) 2025 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -191,6 +191,10 @@ function(dependency)
         "${multiValueArgs}"
         ${ARGN}
     )
+
+    if(POLICY CMP0135)
+        cmake_policy(SET CMP0135 NEW)
+    endif()
 
     # The default URL to use for dependencies declared
     # with the DEPENDENCY_RESOURCE short form

--- a/share/cpp/cmake/DependencyUtil.cmake
+++ b/share/cpp/cmake/DependencyUtil.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Raven Computing
+# Copyright (C) 2025 Raven Computing
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -191,6 +191,10 @@ function(dependency)
         "${multiValueArgs}"
         ${ARGN}
     )
+
+    if(POLICY CMP0135)
+        cmake_policy(SET CMP0135 NEW)
+    endif()
 
     # The default URL to use for dependencies declared
     # with the DEPENDENCY_RESOURCE short form


### PR DESCRIPTION
Adds handling for CMake Policy [CMP0135](https://cmake.org/cmake/help/v3.24/policy/CMP0135.html#policy:CMP0135).
